### PR TITLE
Remove links to rust-lang.org.

### DIFF
--- a/toktok/get-started.md
+++ b/toktok/get-started.md
@@ -14,8 +14,3 @@ When in doubt, you can always [contact us](index.html#contact-us) :-)
 ## C
 
 -   [Start with C by Enlightenment](https://www.enlightenment.org/docs/c/start)
-
-## Rust
-
--   [The Rust Reference](https://doc.rust-lang.org/reference.html)
--   [Start with Rust](https://www.rust-lang.org/en-US/documentation.html)


### PR DESCRIPTION
1. They fail the linkchecker with the following error:
```
URL        `https://www.rust-lang.org/en-US/documentation.html'
Name       `Start with Rust'
Parent URL file:///home/travis/build/TokTok/website/toktok-site/get-started.html, line 130, col 7
Real URL   https://www.rust-lang.org/en-US/documentation.html
Check time 0.592 seconds
Result     Error: SSLError: [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
```
2. We don't currently have any Rust code in the Toktok repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/41)
<!-- Reviewable:end -->
