### PR TITLE
Exclude template files from site generation

### DIFF
--- a/toktok/_config.yml
+++ b/toktok/_config.yml
@@ -7,3 +7,7 @@ markdown: kramdown
 
 kramdown:
   header_offset: 1
+
+# do not generate pages from templates
+exclude:
+  - "*.dist"


### PR DESCRIPTION
Currently the spec is broken: http://toktok.ltd/spec.html

This is caused by spec.md and spec.md.dist, both generate a page with
the same permalink. Added a config to Jekyll to ignore these *.dist
files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/43)
<!-- Reviewable:end -->
