### PR TITLE
Reduce font size and fix underline in PR table.

### DIFF
--- a/toktok/_sass/_main.scss
+++ b/toktok/_sass/_main.scss
@@ -27,7 +27,7 @@ body {
   margin: 0 auto;
   padding: 0;
   font-family: $main-fonts;
-  font-size: 18px;
+  font-size: 16px;
   color: #333;
   line-height: 1.428571429;
 
@@ -343,7 +343,7 @@ tr.packet-row:nth-child(odd) {
 }
 
 .tooltip {
-  display: inline-block;
+  display: inline;
   // If you want dots under the hoverable text
   border-bottom: 1px dotted black;
 


### PR DESCRIPTION
Fixes line break in nav on OS X and weird underline behaviour on long PR titles in the PR table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/66)
<!-- Reviewable:end -->
