### PR TITLE
Add polyfill to make PR table work in old browsers.

### DIFF
--- a/toktok/static/js/pr-table.js
+++ b/toktok/static/js/pr-table.js
@@ -1,3 +1,29 @@
+// Polyfill for replaceWith for IE, Firefox < v49, and Safari
+// from: https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/replaceWith()/replaceWith().md
+(function (arr) {
+  arr.forEach(function (item) {
+    if (item.hasOwnProperty('replaceWith')) {
+      return;
+    }
+    Object.defineProperty(item, 'replaceWith', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function replaceWith() {
+        var argArr = Array.prototype.slice.call(arguments),
+          docFrag = document.createDocumentFragment();
+
+        argArr.forEach(function (argItem) {
+          var isNode = argItem instanceof Node;
+          docFrag.appendChild(isNode ? argItem : document.createTextNode(String(argItem)));
+        });
+
+        this.parentNode.replaceChild(docFrag, this);
+      }
+    });
+  });
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
+
 function escapeHTML(text) {
     return text
       .replace(/&/g, "&amp;")


### PR DESCRIPTION
Big thanks to @cebe for noticing that the PR table is broken in e.g. Debian stable's Firefox.
I tested this PR and verified that it works on IE and Edge.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/71)
<!-- Reviewable:end -->
