### PR TITLE
fixed jekyll install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ The new website with something better than Yst (also, change the title)
 
 To work on the website you need the following things:
 
-- Jekyll and mdl via ruby gems: `gem install jekyll mdl` (mdl is optional, for linting the markdown).
+- Jekyll and mdl via ruby gems: `gem install jekyll mdl guard-livereload`.
+  You might need ruby development headers for this to work: `apt-get install ruby-dev`.
+  Also in case of trouble [this](https://github.com/jekyll/jekyll/issues/5165#issuecomment-236341627) may help (install `gem install bundler`).
+  `mdl` is optional for linting the markdown.
 - pandoc, version 1.10 or higher
   (optional for building the spec).
 


### PR DESCRIPTION
some systems may fail to install the gem and one needs to install
bundler manuall for some weird reason. Added this to the readme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/73)
<!-- Reviewable:end -->
