### PR TITLE
Remove jvm-linters from the website.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ check:
 	mkdir -p ~/.linkchecker/
 	echo "[filtering]" > ~/.linkchecker/linkcheckerrc
 	echo "ignorewarnings=http-robots-denied,https-certificate-error" >> ~/.linkchecker/linkcheckerrc
-	linkchecker --ignore-url "https://toktok.ltd.*" --ignore-url "https://travis-ci.org.*" --ignore-url "irc://.*" --ignore-url "^javascript:" toktok-site
+	linkchecker --ignore-url "https://toktok.ltd.*" --ignore-url "https://msgpack.org.*" --ignore-url "https://travis-ci.org.*" --ignore-url "irc://.*" --ignore-url "^javascript:" toktok-site
 
 upload: toktok-site
 	@test -d $(WEB_NAME) || git clone --depth=1 $(WEB_REPO)

--- a/toktok/_data/repos.yml
+++ b/toktok/_data/repos.yml
@@ -7,7 +7,6 @@
 - name: hs-toxcore
 - name: hs-toxcore-c
 - name: js-toxcore-c
-- name: jvm-linters
 - name: jvm-macros
 - name: jvm-sbt-plugins
 - name: jvm-toxcore-api


### PR DESCRIPTION
This repo is gone. We don't have the resources to maintain it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/77)
<!-- Reviewable:end -->
