### PR TITLE
Keep Rust integrations up-to-date

### DIFF
--- a/toktok/integrations.md
+++ b/toktok/integrations.md
@@ -87,8 +87,7 @@ yourself to this page.
 *   [Python](https://github.com/TokTok/py-toxcore-c)
 *   [Racket](https://github.com/lehitoskin/libtoxcore-racket)
 *   [Ruby](https://github.com/toxon/tox.rb)
-*   [Rust](https://github.com/quininer/tox-rs) tox-rs
-*   [Rust](https://github.com/suhr/rstox) rstox
+*   [Rust](https://github.com/tox-rs/rstox) rstox
 *   [Vala](https://github.com/naxuroqa/vala-toxcore-c)
 
 # Other

--- a/toktok/integrations.md
+++ b/toktok/integrations.md
@@ -107,7 +107,6 @@ yourself to this page.
 *   [ToxIRC](https://github.com/endoffile78/toxirc)
 *   [tox-prpl](https://github.com/jin-eld/tox-prpl)
 *   [ToxSuite](https://github.com/bignaux/ToxSuite)
-*   [ToxSync](https://github.com/MKras/ToxSync)
 *   [ToxVPN](https://github.com/cleverca22/toxvpn)
 *   [Tox-Weechat](https://github.com/haavard/tox-weechat)
 *   [Tuntox](https://github.com/gjedeer/tuntox)


### PR DESCRIPTION
* Remove https://github.com/quininer/tox-rs because the repository has been archived by the owner and updated 3 years ago.
* Move https://github.com/suhr/rstox -> https://github.com/tox-rs/rstox because @suhr moved it to @tox-rs org
* Remove dead link to https://github.com/MKras/ToxSync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/140)
<!-- Reviewable:end -->
