### PR TITLE
fix: Change changelog link to point to github c-toxcore

### DIFF
--- a/toktok/index.md
+++ b/toktok/index.md
@@ -38,7 +38,8 @@ tracker](https://github.com/TokTok/c-toxcore/issues).
 # Contributing
 
 Check out our [roadmap](roadmap.html) and
-[changelog](changelog/c-toxcore.html). If you want to help, you could start by
+[changelog](https://github.com/TokTok/c-toxcore/blob/master/CHANGELOG.md).
+If you want to help, you could start by
 [reviewing](reviews.html) pull requests. You can view the list of
 [repositories](repos.html) and their build status. If one of them has low
 coverage, you could familiarise yourself with the code by writing some tests.


### PR DESCRIPTION
The existing changelog link points to a non-functioning page. Should now be pointing to the github repository's CHANGELOG.md file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/website/257)
<!-- Reviewable:end -->
