### PR TITLE
chore: Use GPL license with https.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -18,5 +18,4 @@ branches:
           - "Header rules - toktok"
           - "Pages changed - toktok"
           - "Redirect rules - toktok"
-          - "Mixed content - toktok"
           - "netlify/toktok/deploy-preview"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,3 @@
 load("//tools/project:build_defs.bzl", "project")
 
-project()
+project(license = "gpl3-https")

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir LinkChecker
 
-RUN ["gem", "install", "--no-document", "jekyll", "guard-livereload", "mdl"]
+RUN ["gem", "install", "--no-document", "jekyll:4.2.2", "guard-livereload", "mdl"]
 
 RUN groupadd -r -g 1000 builder \
  && useradd --no-log-init -r -g builder -u 1000 builder

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,12 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
-
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-command = "gem install --no-document jekyll guard-livereload && make hs-toxcore && make toktok-site"
+command = "gem install --no-document jekyll:4.2.2 guard-livereload sass-embedded:1.6.2 && make hs-toxcore && make toktok-site"
 publish = "toktok-site"

--- a/toktok/designs/testing.md
+++ b/toktok/designs/testing.md
@@ -145,36 +145,36 @@ follows:
 The test input is a length-prefixed test name and an arbitrary piece of data.
 The meaning of that data depends on the test name.
 
-Field     | Type     | Length
---------- | -------- | ------
-length    | `Int`    | 8 bytes
-test name | `String` | `$length` bytes
-test data | `Bytes`  | Depends on test name
+| Field     | Type     | Length               |
+| --------- | -------- | -------------------- |
+| length    | `Int`    | 8 bytes              |
+| test name | `String` | `$length` bytes      |
+| test data | `Bytes`  | Depends on test name |
 
 ### Test Result (SUT’s stdout)
 
 In case of error, a `Failure` message is returned:
 
-Field            | Type     | Length
----------------- | -------- | ------
-0x00 (`Failure`) | `Tag`    | 1 byte
-length           | `Int`    | 8 bytes
-error message    | `String` | `$length` bytes
+| Field            | Type     | Length          |
+| ---------------- | -------- | --------------- |
+| 0x00 (`Failure`) | `Tag`    | 1 byte          |
+| length           | `Int`    | 8 bytes         |
+| error message    | `String` | `$length` bytes |
 
 In case of success, an arbitrary piece of data is returned, depending on the
 test name in the input.
 
-Field            | Type     | Length
----------------- | -------- | ------
-0x01 (`Success`) | `Tag`    | 1 byte
-result data      | `Bytes`  | Depends on test name
+| Field            | Type     | Length               |
+| ---------------- | -------- | -------------------- |
+| 0x01 (`Success`) | `Tag`    | 1 byte               |
+| result data      | `Bytes`  | Depends on test name |
 
 Tests can be skipped by sending a `Skipped` result. These tests will be
 ignored and reported as successful.
 
-Field            | Type     | Length
----------------- | -------- | ------
-0x02 (`Skipped`) | `Tag`    | 1 byte
+| Field            | Type     | Length |
+| ---------------- | -------- | ------ |
+| 0x02 (`Skipped`) | `Tag`    | 1 byte |
 
 ## Reference cross-validation
 


### PR DESCRIPTION
This aligns with the new zig-toxcore-c repo. It is a chore, but better than changing the zig-toxcore-c license to not use https.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/website/261)
<!-- Reviewable:end -->
